### PR TITLE
Data Fetch 메소드 api 하위로 이동

### DIFF
--- a/pages/[category].js
+++ b/pages/[category].js
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import Cards from '../components/Cards';
+import { getCategoryData } from './api/newsletter';
 
 const categories = [
   { code: 'economy', title: '경제' },
@@ -41,16 +42,13 @@ export const getStaticPaths = async () => {
 };
 
 export const getStaticProps = async ({ params }) => {
-  const res = await fetch(
-    `https://newleka.herokuapp.com/newsletters?category=${params.category}`,
-  );
-  let newsletters = await res.json();
+  const newsletters = await getCategoryData(params.category);
 
   return {
     props: {
       newsletters,
     },
-    revalidate: 1,
+    revalidate: 10,
   };
 };
 

--- a/pages/api/newsletter.js
+++ b/pages/api/newsletter.js
@@ -1,0 +1,38 @@
+export async function getAllData() {
+  const res = await fetch(
+    "https://newleka.herokuapp.com/newsletters?_limit=-1"
+  );
+  const newsletters = res.json();
+
+  return newsletters;
+}
+
+export async function getCnt() {
+  const res = await fetch("https://newleka.herokuapp.com/newsletters/count");
+  const cnt = res.json();
+
+  return cnt;
+}
+
+export async function getAlert() {
+  const res = await fetch("https://newleka.herokuapp.com/alerts/1");
+  const alert = res.json();
+
+  return alert;
+}
+
+export async function getCategoryData(category) {
+  const res = await fetch(
+    `https://newleka.herokuapp.com/newsletters?category=${category}`
+  );
+  const newsletters = res.json();
+
+  return newsletters;
+}
+
+export async function getSearchResult(query) {
+  const res = await fetch(`https://newleka.herokuapp.com/newsletters?${query}`);
+  const newsletters = await res.json();
+
+  return newsletters;
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,18 +5,10 @@ import Cards from "../components/Cards";
 import Alert from "../components/Alert";
 import SkeletonCard from "../components/SkeletonCard";
 import cardsStyles from "../styles/Cards.module.css";
+import { getAlert, getAllData, getCnt } from "./api/newsletter";
 
 export default function Home({ newsletters, newslettersCnt, alertContent }) {
-  let m = newsletters.length;
-  let t;
-  let i;
-  while (m) {
-    i = Math.floor(Math.random() * m--);
-    t = newsletters[m];
-    newsletters[m] = newsletters[i];
-    newsletters[i] = t;
-  }
-  const [newsletterList, setNewsletterList] = useState(newsletters);
+  const [newsletterList, setNewsletterList] = useState(newsletters.slice(0, 18));
   const [hasMore, setHasMore] = useState(true);
 
   const loadingSkltnComponent = (
@@ -31,20 +23,7 @@ export default function Home({ newsletters, newslettersCnt, alertContent }) {
   );
 
   const getMoreNewsletters = async () => {
-    const res = await fetch(
-      `https://newleka.herokuapp.com/newsletters?_start=${newsletterList.length}&_limit=18`
-    );
-    const newNewsletterList = await res.json();
-
-    let m = newNewsletterList.length;
-    let t;
-    let i;
-    while (m) {
-      i = Math.floor(Math.random() * m--);
-      t = newNewsletterList[m];
-      newNewsletterList[m] = newNewsletterList[i];
-      newNewsletterList[i] = t;
-    }
+    const newNewsletterList = newsletters.slice(newsletterList.length, newsletterList.length + 18);
 
     setNewsletterList((newsletterList) => [
       ...newsletterList,
@@ -83,34 +62,27 @@ export default function Home({ newsletters, newslettersCnt, alertContent }) {
 }
 
 export const getStaticProps = async () => {
-  const res = await fetch(
-    `https://newleka.herokuapp.com/newsletters?_limit=18`
-  );
-  const newsletters = await res.json();
+  const newsletters = await getAllData();
+  const alertContent = await getAlert();
 
-  const resAlert = await fetch(`https://newleka.herokuapp.com/alerts/1`);
-  const alertContent = await resAlert.json();
+  let m = newsletters.length;
+  let t;
+  let i;
+  while (m) {
+    i = Math.floor(Math.random() * m--);
+    t = newsletters[m];
+    newsletters[m] = newsletters[i];
+    newsletters[i] = t;
+  };
 
-  const resNewslettersCnt = await fetch(
-    `https://newleka.herokuapp.com/newsletters/count`
-  );
-  const newslettersCnt = await resNewslettersCnt.json();
+  const newslettersCnt = await getCnt();
 
-  // let m = newsletters.length;
-  // let t;
-  // let i;
-  // while (m) {
-  //   i = Math.floor(Math.random() * m--);
-  //   t = newsletters[m];
-  //   newsletters[m] = newsletters[i];
-  //   newsletters[i] = t;
-  // }
   return {
     props: {
       newsletters,
       newslettersCnt: +newslettersCnt,
       alertContent,
     },
-    revalidate: 1,
+    revalidate: 10,
   };
 };

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,5 +1,6 @@
 import Cards from '../components/Cards';
 import qs from 'qs';
+import { getSearchResult } from './api/newsletter';
 
 const search = ({ newsletters }) => {
   // const filterQuery = router.query.filter;
@@ -39,10 +40,7 @@ export const getServerSideProps = async (context) => {
     },
   });
 
-  const res = await fetch(
-    `https://newleka.herokuapp.com/newsletters?${query}`,
-  );
-  const newsletters = await res.json();
+  const newsletters = await getSearchResult(query);
 
   return {
     props: {


### PR DESCRIPTION
- 504에러를 해결하기 위해 getServerSideProps에서 getStaticProps로 변경 후 랜덤모두보기가 제대로 동작하지 않거나 초기 infiniteScroll에서 데이터 로드가 지나치게 오래 걸리는 문제 발생. 
- 위의 문제를 해결하기 위해서 뉴스레터 데이터를 전체 가져온 후 순서를 랜덤으로 변경하고 잘라서 infiniteScroll로 가져오도록 수정.
- 데이터를 가져오는 메소드를 모두 api로 옮김.